### PR TITLE
(TestTypeSearch): searching by short_name also

### DIFF
--- a/app/models/test_type.rb
+++ b/app/models/test_type.rb
@@ -1,10 +1,8 @@
 class TestType < ApplicationRecord
 
     def self.get_test_type_id(type)
-        res = TestType.where(:name => type)
-        if !res.blank?
-            return res[0]['id']
-        end
+        res = TestType.where("name = '#{type}' or short_name = '#{type}'")
+        return res[0]['id'] if !res.blank?
     end
 
 end


### PR DESCRIPTION
Fixes issue when saving lab orders from BHT-EMR-API where test type ids were not being saved.